### PR TITLE
Add MPI mode

### DIFF
--- a/xpysom/xpysom.py
+++ b/xpysom/xpysom.py
@@ -437,6 +437,7 @@ class XPySom:
         """
 
         if comm is not None:
+            comm.Barrier()
             mpi_reduce(comm, self._denominator_gpu, self.xp)
             mpi_reduce(comm, self._numerator_gpu, self.xp)
 
@@ -693,7 +694,7 @@ class XPySom:
         # These are host arrays so we do not need to move from device
         if comm is not None:
             import mpi4py.MPI
-            self._weights = comm.Bcast(self._weights)
+            comm.Bcast(self._weights)
 
 
     def pca_weights_init(self, data, comm=None):
@@ -725,7 +726,7 @@ class XPySom:
 
         if comm is not None:
             import mpi4py.MPI
-            self._weights = comm.Bcast(self._weights)
+            comm.Bcast(self._weights)
 
 
     def distance_map(self):

--- a/xpysom/xpysom.py
+++ b/xpysom/xpysom.py
@@ -39,7 +39,7 @@ def mpi_reduce(comm, data, xp):
     # that is mainstream then use it here
 
     if xp.__name__ == 'cupy':
-        tmp = self.xp.asnumpy(data)
+        tmp = xp.asnumpy(data)
         comm.Allreduce(mpi4py.MPI.IN_PLACE, tmp)
         data[:] = xp.asarray(tmp)
     else:


### PR DESCRIPTION
Hi there,

This PR adds the ability to use MPI to parallelize SOM training, by adding a reduction step in the merge_updates.  it should make no difference to non-MPI usage, but allow people to scale across clusters, including GPU clusters.

To make use of it, users pass their mpi4py communicator object, e.g. MPI_COMM_WORLD, to the relevant functions.  I've added some tests, which require the MPI mocking library mockmpi.

No worries if this isn't a feature you're interested in having in the code - I can always maintain it separately.

Cheers,
Joe