### PR TITLE
Pearson correlation distance metric

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(name='XPySom',
       include_package_data=True,
       license="GNU General Public License v3.0",
       packages=['xpysom'],
-      install_requires=['numpy', 'scipy'],
+      install_requires=['numpy', 'scipy', 'tqdm'],
       extras_require={
             'cuda90': ['cupy-cuda90'],
             'cuda92': ['cupy-cuda92'],

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(name='XPySom',
       include_package_data=True,
       license="GNU General Public License v3.0",
       packages=['xpysom'],
-      install_requires=['numpy'],
+      install_requires=['numpy', 'scipy'],
       extras_require={
             'cuda90': ['cupy-cuda90'],
             'cuda92': ['cupy-cuda92'],

--- a/xpysom/distances.py
+++ b/xpysom/distances.py
@@ -41,6 +41,13 @@ def euclidean_distance(x, w, w_sq=None, xp=default_xp):
         )
     )
 
+def correlation_distance(x, w, xp=default_xp):
+    """Calculate Pearson correlation distance
+
+    NB: result shape is (N,X*Y)
+    """
+    return 1 - xp.corrcoef(x, w)[:x.shape[0], x.shape[0]:]
+
 def cosine_distance(x, w, w_sq=None, xp=default_xp):
     """Calculate cosine distance
 
@@ -163,6 +170,7 @@ class DistanceFunction:
             'euclidean_no_opt': euclidean_squared_distance,
             'manhattan': manhattan_distance,
             'manhattan_no_opt': manhattan_distance_no_opt,
+            'correlation': correlation_distance,
             'cosine': cosine_distance,
             'norm_p': norm_p_power_distance,
             'norm_p_no_opt': norm_p_power_distance_generic,

--- a/xpysom/test_distances.py
+++ b/xpysom/test_distances.py
@@ -12,6 +12,7 @@ from .distances import (
     euclidean_squared_distance_part,
     euclidean_squared_distance,
     euclidean_distance,
+    correlation_distance,
     cosine_distance,
     manhattan_distance,
     norm_p_power_distance,
@@ -103,6 +104,15 @@ DISTANCES = [
     (
         euclidean_distance,
         lambda vx, vy: np.linalg.norm(vx - vy),
+        {},
+    ),
+    (
+        correlation_distance,
+        lambda vx, vy: 1 - np.nan_to_num(
+            np.dot(vx - np.mean(vx), vy - np.mean(vy)) / (
+                np.linalg.norm(vx - np.mean(vx)) * np.linalg.norm(vy - np.mean(vy))
+            )
+        ),
         {},
     ),
     (

--- a/xpysom/test_distances.py
+++ b/xpysom/test_distances.py
@@ -1,4 +1,5 @@
 import numpy as np
+import scipy.spatial.distance as distance
 
 XPS = [np]
 try:
@@ -108,11 +109,7 @@ DISTANCES = [
     ),
     (
         correlation_distance,
-        lambda vx, vy: 1 - np.nan_to_num(
-            np.dot(vx - np.mean(vx), vy - np.mean(vy)) / (
-                np.linalg.norm(vx - np.mean(vx)) * np.linalg.norm(vy - np.mean(vy))
-            )
-        ),
+        lambda vx, vy: distance.correlation(vx, vy),
         {},
     ),
     (

--- a/xpysom/tests.py
+++ b/xpysom/tests.py
@@ -11,7 +11,7 @@ except Exception as e:
 from minisom import MiniSom
 
 from .xpysom import XPySom
-from .distances import cosine_distance, manhattan_distance, euclidean_squared_distance
+from .distances import correlation_distance, cosine_distance, manhattan_distance, euclidean_squared_distance
 from .neighborhoods import gaussian_generic, gaussian_rect, mexican_hat_generic, mexican_hat_rect, bubble, triangle, prepare_neig_func
 
 import pickle
@@ -157,6 +157,18 @@ class TestCupySom(unittest.TestCase):
         for i, sample in enumerate(x):
             ms_dist = self.minisom._euclidean_distance(sample, w)**2
             np.testing.assert_array_almost_equal(ms_dist, cs_dist[i])
+
+    def test_correlation_distance(self):
+        x = np.random.rand(100, 20)
+        w = np.random.rand(10,10,20)
+        w_flat = w.reshape(-1, w.shape[2])
+        cs_dist = correlation_distance(self.xp.array(x), self.xp.array(w_flat), xp=self.xp)
+        np_dist = correlation_distance(np.array(x), np.array(w_flat), xp=np)
+        if self.xp.__name__ == 'cupy':
+            cs_dist = cp.asnumpy(cs_dist)
+        cs_dist = cs_dist.reshape((100,10,10))
+        np_dist = np_dist.reshape((100,10,10))
+        np.testing.assert_array_almost_equal(np_dist, cs_dist)
 
     def test_cosine_distance(self):
         x = np.random.rand(100, 20)

--- a/xpysom/xpysom.py
+++ b/xpysom/xpysom.py
@@ -10,6 +10,7 @@ import pickle
 import os
 
 import numpy as np
+from tqdm import tqdm
 try:
     import cupy as cp
     default_xp = cp
@@ -447,7 +448,7 @@ class XPySom:
         if verbose:
             print_progress(-1, num_epochs*len(data))
 
-        for iteration in range(iter_beg, iter_end):
+        for iteration in tqdm(range(iter_beg, iter_end)):
             try: # reuse already allocated memory
                 self._numerator_gpu.fill(0)
                 self._denominator_gpu.fill(0)

--- a/xpysom/xpysom.py
+++ b/xpysom/xpysom.py
@@ -110,7 +110,7 @@ class XPySom:
 
         activation_distance : string, optional (default='euclidean')
             Distance used to activate the map.
-            Possible values: 'euclidean', 'cosine', 'manhattan', 'norm_p'
+            Possible values: 'euclidean', 'correlation', 'cosine', 'manhattan', 'norm_p'
 
         activation_distance_kwargs : dict, optional (default={})
             Pass additional argumets to distance function.


### PR DESCRIPTION
Hey,

this PR adds support for the Pearson correlation distance metric and distance metric test. This increases the usefulness of XPySOM for the application in computational biology where correlation metrics often outperform (see: FuseSOM, [https://www.biorxiv.org/content/10.1101/2023.01.18.524659v2](https://www.biorxiv.org/content/10.1101/2023.01.18.524659v2)).  

This PR should have no impact on users not looking to use the Pearson correlation distance metric. The argument name `correlation` is in line with other packages in the broader ecosystem, e.g., RAPIDS.ai and scipy.

If there are any issues or suggestions, I'll be happy to resolve them. We can always maintain the code separately but would be happy to re-integrate it into the library to increase discoverability.

Best regards,
Malte
